### PR TITLE
docs(backup-path): add README with usage instructions

### DIFF
--- a/packages/dev-script/backup-path/README.md
+++ b/packages/dev-script/backup-path/README.md
@@ -1,0 +1,37 @@
+# backup-path
+
+Creates a timestamped backup copy of a file or directory at `bak/<timestamp>/`.
+
+## What it does
+
+Given a file or directory path, `backup-path` copies it to a new backup location under `bak/<ISO timestamp>/`, preserving timestamps and recursively copying directories.
+
+## Usage
+
+### Via mise (recommended)
+
+```sh
+mise run backup-path <path>
+```
+
+### Direct invocation
+
+```sh
+bun run src/index.ts <path>
+# or
+bunx backup-path <path>
+```
+
+## Arguments
+
+- `path` (required): Path to the file or directory to back up.
+
+## Output
+
+Creates: `bak/<YYYYMMDDTHHMMSS>/<basename-of-path>`
+
+The timestamp directory name uses ISO format with colons removed (e.g., `bak/20260514T103000/`).
+
+## Environment
+
+No environment variables are required.


### PR DESCRIPTION
## Summary

Added a README.md to `packages/dev-script/backup-path/` which was previously a zero-byte file.

The README documents:
- What the script does (creates timestamped backups under `bak/<timestamp>/`)
- How to invoke it via `mise run backup-path <path>` or directly with `bun run`
- The single required argument (`path`)
- The output format (`bak/<YYYYMMDDTHHMMSS>/<basename>`)

## Acceptance Criteria

- [x] `packages/dev-script/backup-path/README.md` is non-empty
- [x] README has a one-line description matching the script's actual behaviour
- [x] README shows how to invoke the script (mise task or direct bun run)
- [x] README documents the CLI argument

## Issue

Fixes #30

---

*No runtime behavior changed — documentation only.*
