### PR TITLE
test(ci): forbidden-strings no-op green verification (#389)

### DIFF
--- a/doc/ci-noop-389.md
+++ b/doc/ci-noop-389.md
@@ -1,0 +1,4 @@
+# CI no-op verification
+
+Throwaway change for issue 389 confirming the forbidden-strings check runs
+green on a clean pull request. This branch is closed unmerged.


### PR DESCRIPTION
Throwaway no-op PR to verify the repaired forbidden-strings CI workflow runs GREEN on a clean pull request (changed-files scan). Closed unmerged; the workflow fix landed via normal main commits under #389.