### PR TITLE
test(ci): forbidden-strings red-case verification (#389)

### DIFF
--- a/redcase-secret-389.txt
+++ b/redcase-secret-389.txt
@@ -1,0 +1,1 @@
+aws_access_key_id = AKIAQQQQQQQQQQQQQQQQ


### PR DESCRIPTION
Throwaway red-case PR: adds a file containing a deny-listed, secret-shaped term from the builtin baseline (constructed only in the API payload, never in a local worktree). Verifies the forbidden-strings CI check goes RED with redacted output only. Closed unmerged and the branch deleted.