### PR TITLE
fix(*): patch GHSA-mh99-v99m-4gvg / CVE-2026-14257

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,7 @@ overrides:
   '@ungap/structured-clone': link:package/shim/ungap-structured-clone
   abort-controller: '-'
   argparse: '-'
+  brace-expansion: '>=5.0.8'
   dprint: '-'
   fast-uri: '>=3.1.2'
   fast-xml-builder: '>=1.1.7'
@@ -5378,9 +5379,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==, tarball: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz}
@@ -8151,7 +8152,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9316,7 +9317,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -236,6 +236,12 @@ overrides:
   # (last commit 2022-05).
   # See doc/troubleshooting/dependencies.md and doc/dependency-blocklist.md.
   'argparse': '-'
+  # Patch GHSA-mh99-v99m-4gvg / CVE-2026-14257: <=5.0.7 bounds the number of
+  # expand() results but not their length, so a chain of brace groups can
+  # exhaust memory and crash the process with an uncatchable OOM. Only
+  # transitive consumer is minimatch@10.2.5 (`brace-expansion: ^5.0.5`);
+  # patch-level bump is range-compatible.
+  'brace-expansion': '>=5.0.8'
   # Remove dprint globally. The npm distribution is a Node wrapper that re-execs
   # the native binary; each invocation pays the Node startup cost (multiple
   # seconds in this workspace, vs sub-100ms for the native binary directly).


### PR DESCRIPTION
## Summary
- Bump `brace-expansion` from 5.0.7 to 5.0.8 via a pnpm override (transitive-only dependency, no manifest declares it directly).
- `<=5.0.7` bounds the number of `expand()` results but not their length; chaining brace groups can exhaust memory and crash the Node process with an uncatchable OOM.
- Sole transitive consumer is `minimatch@10.2.5` (`brace-expansion: ^5.0.5`, pulled in via `@earendil-works/pi-coding-agent`, `@electron/asar`, and `glob`); the patch-level bump is range-compatible.

Resolves https://github.com/Aquaticat/Monochromatic/security/dependabot/74.

## Test plan
- [x] `pnpm install` regenerates the lockfile with only the `brace-expansion` override + resolution/snapshot lines changed.
- [x] `pnpm why brace-expansion` shows a single resolved version, 5.0.8, across all consumers.